### PR TITLE
Adding the ability to import consumption data from a CSV file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,16 @@ The process starts with fetching the usage data from could watch. Fill in the fi
 When you have filled out the fields, hit the "Fetch Cloudwatch Data" button. This will retrieve the usage data for that
 table for the previous week. This data will show up on the chart below.
 
+### Fetching data from a CSV file
+
+If you aren't getting your data out of Cloudwatch, you can also upload a CSV file to populate the consumption data. The
+CSV file must have exactly two columns `time` and `value` in that order.
+
+| Header  | Description                                                                                                                                              |
+|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `time`  | Timestamp in ISO format. It must have 0 in the seconds and milliseconds fields. The data can be at any interval, the app will interpolate between points |
+| `value` | Floating point number of reads/writes per second                                                                                                         |
+
 ### Provisioned Capacity from Auto Scaling
 
 Earl doesn't use cloud watch to display the provisioned capacity. Instead, Earl will use the inputs in the "Auto Scaling 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,11 @@ dependencies {
 
     implementation("com.amazonaws:aws-java-sdk-cloudwatch")
 
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/src/main/kotlin/io/atlassian/earl/controller/CloudWatchMetricsController.kt
+++ b/src/main/kotlin/io/atlassian/earl/controller/CloudWatchMetricsController.kt
@@ -13,7 +13,7 @@ class CloudWatchMetricsController(
         metric: String,
         region: Regions,
         tableName: String,
-    ): CloudWatchDataResult {
+    ): ConsumedResourcesData {
         val data = cloudWatchMetricsFetcher.getMetricsForTable(
             indexName = indexName,
             metricName = metric,
@@ -21,7 +21,7 @@ class CloudWatchMetricsController(
             tableName = tableName
         )
 
-        return CloudWatchDataResult(
+        return ConsumedResourcesData(
             data = data.map { it.time.toEpochMilli() to it.value },
             lower = data.minOf { it.time }.toEpochMilli().toDouble(),
             upper = data.maxOf { it.time }.toEpochMilli().toDouble()
@@ -36,7 +36,7 @@ class CloudWatchMetricsController(
  * @param lower Lower bound of the X-axis
  * @param upper Upper bound of the X-axis
  */
-data class CloudWatchDataResult(
+data class ConsumedResourcesData(
     val data: List<Pair<Number, Number>>,
     val lower: Double,
     val upper: Double

--- a/src/main/kotlin/io/atlassian/earl/controller/CsvFileController.kt
+++ b/src/main/kotlin/io/atlassian/earl/controller/CsvFileController.kt
@@ -1,0 +1,18 @@
+package io.atlassian.earl.controller
+
+import io.atlassian.earl.csvfile.CsvFileFetcher
+import org.springframework.stereotype.Component
+import java.io.File
+
+@Component
+class CsvFileController(
+    private val csvFileFetcher: CsvFileFetcher
+) {
+    fun getData(csvFile: File) = csvFileFetcher.getUsageData(csvFile).let {
+        ConsumedResourcesData(
+            data = it.map { r -> r.time.toEpochMilli() to r.value },
+            lower = it.minOf { x -> x.time }.toEpochMilli().toDouble(),
+            upper = it.maxOf { x -> x.time }.toEpochMilli().toDouble()
+        )
+    }
+}

--- a/src/main/kotlin/io/atlassian/earl/csvfile/CsvFileFetcher.kt
+++ b/src/main/kotlin/io/atlassian/earl/csvfile/CsvFileFetcher.kt
@@ -1,0 +1,54 @@
+package io.atlassian.earl.csvfile
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.dataformat.csv.CsvMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import org.springframework.stereotype.Component
+import java.io.File
+import java.time.Duration
+import java.time.Instant
+
+@Component
+class CsvFileFetcher {
+    private val mapper = CsvMapper()
+        .registerModule(kotlinModule())
+        .registerModule(JavaTimeModule())
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES) as CsvMapper
+
+    fun getUsageData(file: File): List<Record> {
+        val schema = mapper.schemaFor(Record::class.java).withHeader()
+        val data = mapper.readerFor(Record::class.java)
+            .with(schema)
+            .readValues<Record>(file)
+            .asSequence()
+            .toList()
+            .sortedBy { it.time }
+
+        return data.flatMapIndexed { i: Int, _: Record ->
+            when {
+                i < (data.size - 1) -> fillInBlanksForMinutes(data[i], data[i + 1])
+                else -> listOf(data[i])
+            }
+        }
+    }
+
+    private fun fillInBlanksForMinutes(startRecord: Record, endRecord: Record): List<Record> {
+        val interval = Duration.between(startRecord.time, endRecord.time)
+
+        if (interval.toMinutes() <= 1) return listOf(startRecord)
+
+        // This is super basic and assumes that this interval fits nicely in the data points
+        return (startRecord.time.epochSecond until endRecord.time.epochSecond step 60).map {
+            val interpolationFactor = (it - startRecord.time.epochSecond).toDouble() / interval.toSeconds()
+            val interpolatedValue = startRecord.value + (endRecord.value - startRecord.value) * interpolationFactor
+
+            Record(Instant.ofEpochSecond(it), interpolatedValue)
+        }
+    }
+}
+
+data class Record(
+    val time: Instant,
+    val value: Double
+)

--- a/src/test/kotlin/io/atlassian/earl/controller/CsvFileControllerTest.kt
+++ b/src/test/kotlin/io/atlassian/earl/controller/CsvFileControllerTest.kt
@@ -1,0 +1,62 @@
+package io.atlassian.earl.controller
+
+import io.atlassian.earl.csvfile.CsvFileFetcher
+import io.atlassian.earl.csvfile.Record
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeEach
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.File
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+internal class CsvFileControllerTest {
+
+    @Mock
+    private lateinit var csvFileFetcher: CsvFileFetcher
+
+    @Mock
+    private lateinit var mockFile: File
+
+    private lateinit var csvFileController: CsvFileController
+
+    private lateinit var testData: List<Record>
+
+    @BeforeEach
+    fun setUp() {
+        csvFileController = CsvFileController(csvFileFetcher)
+
+        testData = listOf(
+            Record(time = Instant.ofEpochSecond(1), value = 42.0),
+            Record(time = Instant.ofEpochSecond(2), value = 69.0),
+        )
+
+        whenever(csvFileFetcher.getUsageData(mockFile)).thenReturn(testData)
+    }
+
+    @Test
+    fun `getData should return the data correctly`() {
+        val result = csvFileController.getData(mockFile)
+        assertThat(result.data).contains(1000L to 42.0, 2000L to 69.0)
+    }
+
+    @Test
+    fun `getData should return the min value correctly`() {
+        val result = csvFileController.getData(mockFile)
+        assertThat(result.lower).isCloseTo(1000.0, Offset.offset(0.001))
+    }
+
+    @Test
+    internal fun `getData should return the max value correctly`() {
+        val result = csvFileController.getData(mockFile)
+        assertThat(result.upper).isCloseTo(2000.0, Offset.offset(0.001))
+    }
+}

--- a/src/test/kotlin/io/atlassian/earl/csvfile/CsvFileFetcherTest.kt
+++ b/src/test/kotlin/io/atlassian/earl/csvfile/CsvFileFetcherTest.kt
@@ -1,0 +1,74 @@
+package io.atlassian.earl.csvfile
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.AutoCloseableSoftAssertions
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+
+class CsvFileFetcherTest {
+    companion object {
+        @JvmStatic
+        @TempDir
+        lateinit var tempDir: Path
+
+        lateinit var tempFile: File
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp() {
+            tempFile = Files.createFile(tempDir.resolve("testing-${Instant.now().toEpochMilli()}.csv")).toFile()
+
+            tempFile.writeText(
+                """time,value
+                    2022-11-11T00:00:00.000Z,0
+                    2022-11-11T01:00:00.000Z,60
+                    2022-11-11T02:00:00.000Z,120
+                """.trimIndent()
+            )
+        }
+    }
+
+    private lateinit var csvFileFetcher: CsvFileFetcher
+
+    @BeforeEach
+    internal fun setUp() {
+        csvFileFetcher = CsvFileFetcher()
+    }
+
+    @Test
+    fun `getData will return some data`() {
+        val result = csvFileFetcher.getUsageData(tempFile)
+
+        assertThat(result).isNotEmpty
+    }
+
+    @Test
+    fun `getData will interpolate between missing timestamps to make the data granular to one minute`() {
+        val result = csvFileFetcher.getUsageData(tempFile)
+
+        assertThat(result).hasSize(2 * 60 + 1)  // 2 hours of data plus one record
+    }
+
+    @Test
+    fun `getData will interpolate correctly`() {
+        val result = csvFileFetcher.getUsageData(tempFile)
+        val startTime = Instant.parse("2022-11-11T00:00:00.000Z")
+
+        AutoCloseableSoftAssertions().use { softly ->
+            (0..120).forEach {
+                val expected = Record(startTime.plus(Duration.ofMinutes(it.toLong())), it.toDouble())
+
+                softly.assertThat(result[it].time).isEqualTo(expected.time)
+                softly.assertThat(result[it].value).isCloseTo(expected.value, Offset.offset(0.001))
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/atlassian/earl/csvfile/CsvFileFetcherTest.kt
+++ b/src/test/kotlin/io/atlassian/earl/csvfile/CsvFileFetcherTest.kt
@@ -31,6 +31,8 @@ class CsvFileFetcherTest {
                     2022-11-11T00:00:00.000Z,0
                     2022-11-11T01:00:00.000Z,60
                     2022-11-11T02:00:00.000Z,120
+                    2022-11-11T02:05:00.000Z,125
+                    2022-11-11T02:06:00.000Z,126
                 """.trimIndent()
             )
         }
@@ -54,7 +56,7 @@ class CsvFileFetcherTest {
     fun `getData will interpolate between missing timestamps to make the data granular to one minute`() {
         val result = csvFileFetcher.getUsageData(tempFile)
 
-        assertThat(result).hasSize(2 * 60 + 1)  // 2 hours of data plus one record
+        assertThat(result).hasSize(2 * 60 + 6 + 1)  // 2 hours, 6 minutes of data plus one record
     }
 
     @Test
@@ -63,7 +65,7 @@ class CsvFileFetcherTest {
         val startTime = Instant.parse("2022-11-11T00:00:00.000Z")
 
         AutoCloseableSoftAssertions().use { softly ->
-            (0..120).forEach {
+            (0..126).forEach {
                 val expected = Record(startTime.plus(Duration.ofMinutes(it.toLong())), it.toDouble())
 
                 softly.assertThat(result[it].time).isEqualTo(expected.time)


### PR DESCRIPTION
The current Earl is restricted to only reading consumption data from a Cloudwatch. This enables the import from a CSV file too. Handy for when you need to put in metrics from other types of DBs that you are considering moving to DynamoDb