### PR TITLE
Updating the default prices in the interface.

### DIFF
--- a/src/main/kotlin/io/atlassian/earl/views/MainView.kt
+++ b/src/main/kotlin/io/atlassian/earl/views/MainView.kt
@@ -437,7 +437,7 @@ private class AutoScalingConfigViewModel : ViewModel() {
 }
 
 private class CostViewModel : ViewModel() {
-    val provisionedPrice = bind { SimpleDoubleProperty(0.00065) }
+    val provisionedPrice = bind { SimpleDoubleProperty(0.00013) }
     val onDemandPrice = bind { SimpleDoubleProperty(0.25) }
 
     val totalProvisionedCost = bind { SimpleDoubleProperty(0.0) }


### PR DESCRIPTION
I just noticed that the defaults are comparing apples and oranges. The previous one showed WCU and RRU costs. Now it shows RCU and RRU costs.

Hopefully no one made any decisions with the default numbers in there 😅